### PR TITLE
Windows network files store invalid locations

### DIFF
--- a/history.py
+++ b/history.py
@@ -29,7 +29,7 @@ def get_file_dir(file_path):
     file_dir = os.path.dirname(file_path)
     if platform.system() == "Windows":
         if file_dir.find(os.sep) == 0:
-            file_dir = file_dir[1:]  # Strip the network \\ starting path
+            file_dir = file_dir[2:]  # Strip the network \\ starting path
         if file_dir.find(":") == 1:
             file_dir = file_dir.replace(":", "", 1)
     else:


### PR DESCRIPTION
I found that the history of files with a network path are being stored on my C: root.  It seems if you pass a path beginning with a slash to os.path.join, it will use that path at the root.

example:

```
os.path.join("C:\Users\tollus\.sublime\history", "\server1\files\something.config") 
== "C:\server1\files\something.config"
```

So we need to strip both slashes at the beginning of the network path. (\\server1\files\something.config)
