### PR TITLE
Option to only save history on closing a view

### DIFF
--- a/LocalHistory.sublime-settings
+++ b/LocalHistory.sublime-settings
@@ -1,4 +1,5 @@
 {
   "file_history_retention": 30, // In days
-  "file_size_limit": 262144 // 256 KiB
+  "file_size_limit": 262144, // 256 KiB
+  "history_on_close": false // "true" to store on closing a view
 }


### PR DESCRIPTION
This patch adds a setting, "history_on_close", that when set to "true" will only run the history check when a view is closed. This reduces the stored changes to major ones.

I was noticing that when working on long, frequently-saved-and-compiled LaTeX documents that my history was full of changes of a sentence or two rather than of major changes, and this seemed like a potentially useful way to rectify it.
