### PR TITLE
Fix math log imports for #84

### DIFF
--- a/LocalHistory.py
+++ b/LocalHistory.py
@@ -12,6 +12,12 @@ import sublime
 import sublime_plugin
 
 PY2 = sys.version_info < (3, 0)
+
+if PY2:
+    from math import log
+else:
+    from math import log2
+
 NO_SELECTION = -1
 settings = None
 

--- a/LocalHistory.py
+++ b/LocalHistory.py
@@ -4,7 +4,6 @@ import platform
 import datetime
 import difflib
 import filecmp
-import math
 import shutil
 from threading import Thread
 import subprocess


### PR DESCRIPTION
Added a new import if/else stanza to explicitly pull the correct method. I thought about just changing the import back to `from math import log` and then removing the version specific conditional where it's actually used, but since log2 is actually more accurate (apparently due to floating point calculations), I figured it might be better to be more accurate half the time (read: Python3) than save a few lines of code. Though, feel free to disagree and just reject the request.