### PR TITLE
Fix failing "Browse" command (on Mac)

### DIFF
--- a/LocalHistory.py
+++ b/LocalHistory.py
@@ -249,7 +249,7 @@ class HistoryBrowse(sublime_plugin.TextCommand):
         system = platform.system()
 
         if system == 'Darwin':
-            subprocess.call('open %s' % target_dir)
+            subprocess.call(['open', target_dir])
         elif system == 'Linux':
             subprocess.call('xdg-open %s' % target_dir, shell=True)
         elif system == 'Windows':


### PR DESCRIPTION
when spaces are inside the path to open.

closes #93